### PR TITLE
#36 - add modal for antecedant moisture description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - User Guide (no text provided yet)
 - Antecedant moisture selector
 - Popup in precipitation gage with NWIS gage site link
+- Antecedant moisture description modal
 
 ### Changed
 

--- a/src/components/MapFilters.vue
+++ b/src/components/MapFilters.vue
@@ -73,32 +73,35 @@
             <v-card-text>
               <div class="moistureButtonDiv">
                 <v-subheader>Select an antecedant moisture condition:</v-subheader>
-                <v-btn-toggle mandatory v-model="moistureSelected" class="moistureGroup">
-                  <v-btn
-                    id="dry"
-                    class="moistureBtn"
-                    value="Dry"
-                    elevation="1"
-                    @click="moistureSelected = 'Dry'"
-                  >Dry
-                  </v-btn>
-                  <v-btn
-                    id="normal"
-                    class="moistureBtn"
-                    value="Normal"
-                    elevation="1"
-                    @click="moistureSelected = 'Normal'"
-                  >Normal
-                  </v-btn>
-                  <v-btn
-                    id="wet"
-                    class="moistureBtn"
-                    value="Wet"
-                    elevation="1"
-                    @click="moistureSelected = 'Wet'"
-                  >Wet
-                  </v-btn>
-                </v-btn-toggle>
+                <div class="button-row">
+                  <v-btn-toggle mandatory v-model="moistureSelected" class="moistureGroup">
+                    <v-btn
+                      id="dry"
+                      class="moistureBtn"
+                      value="Dry"
+                      elevation="1"
+                      @click="moistureSelected = 'Dry'"
+                    >Dry
+                    </v-btn>
+                    <v-btn
+                      id="normal"
+                      class="moistureBtn"
+                      value="Normal"
+                      elevation="1"
+                      @click="moistureSelected = 'Normal'"
+                    >Normal
+                    </v-btn>
+                    <v-btn
+                      id="wet"
+                      class="moistureBtn"
+                      value="Wet"
+                      elevation="1"
+                      @click="moistureSelected = 'Wet'"
+                    >Wet
+                    </v-btn>
+                  </v-btn-toggle>
+                  <RunoffModal></RunoffModal>
+                </div>
               </div>
             </v-card-text>
           </v-card>
@@ -161,7 +164,12 @@
 </template>
 
 <script>
+  import RunoffModal from '../components/RunoffModal';
+
   export default {
+    components: {
+      RunoffModal
+    },
     data () {
       return {
         checkbox: true,
@@ -314,6 +322,13 @@
   width: 100%;
 }
 
+.button-row {
+  display: inline-flex;
+  width: 100%;
+  height: 48px;
+  line-height: 48px;
+}
+
 .moistureBtn {
   width: 33%;
 }
@@ -322,6 +337,7 @@
   flex-direction: row;
   width: 100%;
   justify-content: space-evenly;
+  margin-right: 10px;
 }
 
 .moistureButtonDiv {

--- a/src/components/RunoffModal.vue
+++ b/src/components/RunoffModal.vue
@@ -1,0 +1,83 @@
+<template>
+  <div>
+    <v-dialog
+      v-model="dialog"
+      scrollable
+      width="600"
+    >
+      <template v-slot:activator="{ on, attrs }">
+        <v-icon v-bind="attrs" v-on="on">mdi-information-outline</v-icon>
+      </template>
+
+      <v-card>
+        <v-card-text style="height: 600px; padding: 0px;">
+          <v-card-title class="text-h8 runoff-title">
+            Antecedant Moisture
+            <v-icon @click="dialog = false" class="close-icon">mdi-close</v-icon>
+          </v-card-title>
+          <v-card-text class="modal-body">
+           <p>
+                "Variability occurs in the hydrologic response from a precipitation event as the result of rainfall intensity and duration, total rainfall, soil moisture conditions, vegetation cover density and stage of growth, and temperatures (National Resource Conservation Service, 2004).  These factors affecting the hydrologic response are referred to as the Antecedent Runoff Condition (ARC).  The ARC is divided into three classes including Dry, Normal, and Wet and the class selected can have a substantial effect on the hydrologic response.  High temperatures, high vegetation density and cover, and low soil moisture will result in dry conditions.  Low temperatures, low vegetation cover and high soil moisture will result in Wet conditions.  The Normal condition will fall in between these extremes and the selection of the appropriate ARC condition will come with experience and familiarity with the hydroclimatic conditions in the basin. "  
+            </p>
+            <h2>
+                Citations
+            </h2>
+            <p>
+                Natural Resources Conservation Service, 2004, Chapter 10—Estimation of direct runoff from storm rainfall—Part 630 hydrology—National engineering handbook: Washington, D.C., U.S. Department of Agriculture, 22 p. [Also available at https://directives.sc.egov.usda.gov/17752.wba.] 
+            </p>
+          </v-card-text>
+        </v-card-text>
+
+        <v-divider></v-divider>
+
+        <v-card-actions class="footer">
+          <v-spacer></v-spacer>
+          <div>
+            <v-btn
+              color="primary"
+              @click="dialog = false"
+              class="close-btn"
+            >
+              Close
+            </v-btn>
+          </div>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script>
+  export default {
+    data () {
+      return {
+        dialog: false,
+      }
+    },
+  }
+</script>
+
+<style scoped>
+.modal-body {
+  font-size: 12px !important;
+}
+
+.runoff-title {
+  color: rgba(0, 0, 0, 0.54);
+  font-size: 1em;
+}
+
+.footer {
+  flex-direction: column;
+  background-color: #e0e0e0;
+}
+
+.close-btn {
+  text-align: center;
+}
+
+.close-icon {
+    margin-right: 0px;
+    margin-left: auto;
+}
+</style>


### PR DESCRIPTION
Added an info icon button to the right of the moisture condition selectors which opens a modal containing the description/citation.